### PR TITLE
feat: Add initial application structure and health endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from .settings import settings
+from .schemas import HealthResponse
+
+app = FastAPI(
+    title=settings.APP_NAME,
+    description=settings.APP_DESCRIPTION,
+    version=settings.APP_VERSION,
+)
+
+@app.get("/health", response_model=HealthResponse, tags=["Monitoring"])
+async def health_check():
+    return {"status": "ok"}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic-settings

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class HealthResponse(BaseModel):
+    status: str

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,9 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    APP_NAME: str = "Resume Tailor AI"
+    APP_VERSION: str = "0.1.0"
+    APP_DESCRIPTION: str = "Agentic, open-source resume tailor that auto-optimizes your CV for any job description using AI agents."
+
+settings = Settings()


### PR DESCRIPTION
Resolves #3

Hi! This PR sets up the basic FastAPI application and adds the `/health` endpoint as requested.

Here's what I did:
- I created an `app` folder to keep all the Python code organized.
- I added a `settings.py` file so the app's name and version aren't hardcoded.
- I also added a `schemas.py` file for the health check response model, which is a good practice for FastAPI.
- A `requirements.txt` file is now included so other developers can easily install the packages needed to run the project.

You can test this by running `uvicorn app.main:app --reload` and visiting `http://127.0.0.1:8000/health`.